### PR TITLE
add simple bin

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+var argv = require('minimist')(process.argv.slice(2), {boolean: ['w', 'h', 'width', 'height']});
+var svgDim = require('./');
+
+var width  = argv.w || argv.width;
+var height = argv.h || argv.height;
+
+svgDim.get(argv._[0], function(err, dims) {
+	if(err) {
+		console.error(err.stack);
+		process.exit(1);
+	}
+
+	if(width === height) { // both true or both false
+		console.log(dims.width + '×' + dims.height);
+	} else if(width) {
+		console.log(dims.width);
+	} else if(height) {
+		console.log(dims.height);
+	}
+})

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "Returns the height and width attributes of an svg image.",
   "main": "svg-dimensions.js",
+  "bin": "bin.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node svg-dimensions.js"
@@ -27,6 +28,7 @@
   },
   "homepage": "https://github.com/fixiecoder/node-svg-dimensions",
   "dependencies": {
+    "minimist": "^1.2.0",
     "xml2js": "^0.4.5"
   }
 }


### PR DESCRIPTION
when installed globally, you can run `svg-dimensions foo.svg` to output both dimensions, or add `-w`/`--width`/`-h`/`--height` for just one dimension.
